### PR TITLE
Add IsStatic and FunctionVarDefinition

### DIFF
--- a/projects/Gibbed.RED4.ScriptFormats/Definitions/FunctionDefinition.cs
+++ b/projects/Gibbed.RED4.ScriptFormats/Definitions/FunctionDefinition.cs
@@ -51,7 +51,7 @@ namespace Gibbed.RED4.ScriptFormats.Definitions
         public List<Instruction> Code { get; }
 
         private static readonly FunctionFlags KnownFlags =
-            FunctionFlags.Unknown0 | FunctionFlags.IsExec |
+            FunctionFlags.IsStatic | FunctionFlags.IsExec |
             FunctionFlags.Unknown2 | FunctionFlags.Unknown3 |
             FunctionFlags.IsNative | FunctionFlags.IsEvent |
             FunctionFlags.Unknown6 |

--- a/projects/Gibbed.RED4.ScriptFormats/Definitions/FunctionVarDefinition.cs
+++ b/projects/Gibbed.RED4.ScriptFormats/Definitions/FunctionVarDefinition.cs
@@ -24,27 +24,8 @@ using System;
 
 namespace Gibbed.RED4.ScriptFormats.Definitions
 {
-    [Flags]
-    public enum FunctionFlags : uint
+    public abstract class FunctionVarDefinition : Definition
     {
-        None = 0,
-        IsStatic = 1u << 0,
-        IsExec = 1u << 1,
-        Unknown2 = 1u << 2,
-        Unknown3 = 1u << 3,
-        IsNative = 1u << 4,
-        IsEvent = 1u << 5,
-        Unknown6 = 1u << 6,
-        HasReturnValue = 1u << 7,
-        Unknown8 = 1u << 8,
-        HasParameters = 1 << 9,
-        HasLocals = 1 << 10,
-        HasCode = 1u << 11,
-        Unknown12 = 1u << 12,
-        Unknown13 = 1u << 13,
-        IsConstant = 1u << 18,
-        Unknown19 = 1u << 19,
-        Unknown20 = 1u << 20,
-        Unknown21 = 1u << 21,
+        public NativeDefinition Type { get; set; }
     }
 }

--- a/projects/Gibbed.RED4.ScriptFormats/Definitions/LocalDefinition.cs
+++ b/projects/Gibbed.RED4.ScriptFormats/Definitions/LocalDefinition.cs
@@ -24,11 +24,9 @@ using System;
 
 namespace Gibbed.RED4.ScriptFormats.Definitions
 {
-    public class LocalDefinition : Definition
+    public class LocalDefinition : FunctionVarDefinition
     {
         public override DefinitionType DefinitionType => DefinitionType.Local;
-
-        public NativeDefinition Type { get; set; }
         public byte Unknown28 { get; set; }
 
         internal override void Serialize(IDefinitionWriter writer)

--- a/projects/Gibbed.RED4.ScriptFormats/Definitions/ParameterDefinition.cs
+++ b/projects/Gibbed.RED4.ScriptFormats/Definitions/ParameterDefinition.cs
@@ -24,11 +24,9 @@ using System;
 
 namespace Gibbed.RED4.ScriptFormats.Definitions
 {
-    public class ParameterDefinition : Definition
+    public class ParameterDefinition : FunctionVarDefinition
     {
         public override DefinitionType DefinitionType => DefinitionType.Parameter;
-
-        public Definition Type { get; set; }
         public ParameterFlags Flags { get; set; }
 
         private static readonly ParameterFlags KnownFlags =

--- a/projects/ScriptCachePatchTest/Program.cs
+++ b/projects/ScriptCachePatchTest/Program.cs
@@ -136,7 +136,7 @@ namespace ScriptCachePatchTest
             {
                 Name = "STS",
                 Flags =
-                    FunctionFlags.Unknown0 | FunctionFlags.IsExec |
+                    FunctionFlags.IsStatic | FunctionFlags.IsExec |
                     FunctionFlags.HasParameters | FunctionFlags.HasLocals |
                     FunctionFlags.HasCode,
                 SourceFile = mySourceFile,


### PR DESCRIPTION
Adds IsStatic and a base class so only one code path is needed to get the type of a LocalDefinition or ParameterDefinition.